### PR TITLE
TTY is not always needed for stdout after gosu

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Alpine base image includes:
 - `USE_INIT`: If set to any non-empty value, tini will be used to run the
   command, providing repaing of zombie processes
 - `RUN_AS`: If set to any non-empty value, gosu will be used to drop privledges
-  from root to the requested user
+  from root to the requested user (see potential issues writing to /dev/stdout
+  below)
 
 ## Converting Secrets to Environment Variables
 
@@ -116,6 +117,12 @@ The nginx example shows:
 - Volume caching to automatically populate host and tmpfs volumes
 - Entrypoint to automatically fix the uid to match the developer volume mount
 - Using curl for a healthcheck
-- For details on the need for a TTY when writing to /dev/stdout and /dev/stderr
-  see: https://github.com/moby/moby/issues/31243#issuecomment-406879017
+
+## Errors Writing to /dev/stdout
+
+There are scenarios where writing to /dev/stdout and /dev/stderr may fail with
+permission problems when the container starts as root and changes to another
+user. Should you encounter this, try to add the user to the tty group and
+configure the container with a tty. See the following issue for more details:
+https://github.com/moby/moby/issues/31243#issuecomment-406879017
 

--- a/examples/nginx/Dockerfile.alpine
+++ b/examples/nginx/Dockerfile.alpine
@@ -5,11 +5,11 @@ FROM nginx:alpine
 RUN apk add --no-cache \
       curl
 
-# shadow is needed for fix-perm, and also to add the tty group
+# shadow is needed for fix-perm
 #RUN addgroup -S -g 5000 app \                           
 # && adduser -D -S -s /sbin/nologin -G app -u 5000 app \
 RUN apk add --no-cache shadow \
- && useradd -u 5000 -G tty app \
+ && useradd -u 5000 app \
  && sed -i -e 's/^user /#user /' /etc/nginx/nginx.conf \
  && sed -i -e 's#^pid .*$#pid /var/log/nginx/nginx.pid;#' /etc/nginx/nginx.conf \
  && chown -R app:app /var/cache/nginx /var/log/nginx
@@ -21,7 +21,7 @@ COPY conf.d/ /etc/nginx/conf.d/
 COPY --chown=app:app html/ /usr/share/nginx/html/
 RUN  save-volume /usr/share/nginx/html
 
-ENV RUN_AS="app"
+ENV RUN_AS="app:app"
 ENTRYPOINT ["/usr/bin/entrypointd.sh"]
 CMD [ "nginx", "-g", "daemon off;" ]
 HEALTHCHECK CMD /usr/bin/healthcheckd.sh

--- a/examples/nginx/Dockerfile.mainline
+++ b/examples/nginx/Dockerfile.mainline
@@ -6,7 +6,7 @@ RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       curl \
  && rm -rf /var/lib/apt/lists/*
-RUN useradd -u 5000 -G tty app \
+RUN useradd -u 5000 app \
  && sed -i -e 's/^user /#user /' /etc/nginx/nginx.conf \
  && sed -i -e 's#^pid .*$#pid /var/log/nginx/nginx.pid;#' /etc/nginx/nginx.conf \
  && chown -R app:app /var/cache/nginx /var/log/nginx
@@ -18,7 +18,7 @@ COPY conf.d/ /etc/nginx/conf.d/
 COPY --chown=app:app html/ /usr/share/nginx/html/
 RUN  save-volume /usr/share/nginx/html
 
-ENV RUN_AS="app"
+ENV RUN_AS="app:app"
 ENTRYPOINT ["/usr/bin/entrypointd.sh"]
 CMD [ "nginx", "-g", "daemon off;" ]
 HEALTHCHECK CMD /usr/bin/healthcheckd.sh

--- a/examples/nginx/docker-compose.dev.yml
+++ b/examples/nginx/docker-compose.dev.yml
@@ -9,5 +9,3 @@ services:
     - ./conf.d:/etc/nginx/conf.d
     # start as root to automatically correct user permissions
     user: "0:0"
-    # tty needed to have stdout permissions 
-    tty: true

--- a/examples/nginx/entrypoint.d/10-fix-perms.sh
+++ b/examples/nginx/entrypoint.d/10-fix-perms.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$(id -u)" = "0" ]; then
+if [ "$(id -u)" = "0" -a -d /usr/share/nginx/html ]; then
   fix-perms -r -u app -g app /usr/share/nginx/html
 fi
 


### PR DESCRIPTION
The previous change to entrypointd.sh to run a chown on `/proc/$$/fd/1` and `/proc/$$/fd/2` makes it possible to avoid the tty permissions when running gosu.