### PR TITLE
Adding stop-on-trigger script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ These base images include:
 - Secrets imported into environment variables 
 - `save-volume` and `load-volume` to cache and initialize volume data from the
   image in scenarios where docker would not normally do this
+- `stop-on-trigger` which can stop the container on a condition
 
 ## Platform specific additions
 
@@ -107,6 +108,25 @@ moved which will double the size of the directory in the docker layers when
 performed as a separate build step. When possible, merge the `save-volume`
 step with any other commands used to create the volume folder. If copying
 files between stages in a multi-stage build, include `/.volume-cache`.
+
+## Stop On Trigger
+
+The `stop-on-trigger` script can be used to stop a container on a condition.
+This would be launched as a background process in an entrypoint script. When
+the condition is met, all processes are sent a SIGTERM, followed by a delay,
+and then a SIGKILL. However, pid 1 will not receive this signal inside of the
+container so you need to use `tini` to run your app as a child pid. This is
+done by setting `ENV USE_INIT=1` in the image when using entrypointd.sh. A
+sample entrypointd script would look like:
+
+```
+#!/bin/sh
+stop-on-trigger -m /etc/certs/host.pem
+```
+
+Which would stop the container when the file is modified, and any container
+restart policy would result in a new container running, using that new
+certificate file.
 
 ## Examples
 

--- a/bin/stop-on-trigger
+++ b/bin/stop-on-trigger
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+# Copyright Brandon Mitchell
+# License: MIT
+
+usage() {
+  echo "Usage: $(basename $0) [opts]"
+  echo " -e file: restart when file exists (file will be deleted)"
+  echo " -h: this help message"
+  echo " -m file: restart when file modified"
+  echo " -s time: sleep timeout between polling (in seconds)"
+  echo " -t time: timeout to wait for graceful termination (in seconds)"
+  echo "At least one triggering option must be specified (-e, -m)."
+  echo "This script is only supported inside of docker containers."
+  echo "When the condition is met, all processes will be sent SIGTERM, followed"
+  echo "by SIGKILL after a $opt_t second timeout"
+  [ "$opt_h" = "1" ] && exit 0 ||  exit 1
+}
+
+set -e
+trap "{ exit 0; }" TERM INT
+opt_e=""
+opt_m=""
+opt_h=0
+opt_s=1
+opt_t=10
+
+while getopts 'e:hm:s:t:' option; do
+  case $option in
+    e) opt_e="$OPTARG";;
+    h) opt_h=1;;
+    m) opt_m="$OPTARG";;
+    s) opt_s="$OPTARG";;
+    t) opt_t="$OPTARG";;
+  esac
+done
+shift $(expr $OPTIND - 1)
+
+if [ $# -gt 0 -o \( -z "$opt_e" -a -z "$opt_m" \) ]; then
+  usage
+fi
+
+if ! grep -q '1:name=systemd:/docker/' </proc/self/cgroup; then
+  echo "Error: this script is only supported from within a docker container" >&2
+  exit 1
+fi
+
+handle_trigger() {
+  kill -TERM -1 # kill all processes with SIGTERM
+  sleep "$opt_t" # wait for graceful shutdown
+  kill -KILL -1 # kill all processes with SIGKILL
+  kill -KILL 0  # kill this command
+}
+
+check_exists() {
+  while [ ! -f "$opt_e" ]; do
+    sleep "$opt_s"
+  done
+  echo "File exists, killing container: $opt_e" >&2
+  rm "$opt_e"
+  handle_trigger
+}
+
+check_modify() {
+  if [ ! -f "$opt_m" ]; then
+    echo "Error: file does not exist: $opt_m"
+    exit 2
+  fi
+  start_time=$(stat -Lc "%Y" "$opt_m")
+  while [ -f "$opt_m" -a "$start_time" = "$(stat -Lc "%Y" "$opt_m")" ]; do
+    sleep "$opt_s"
+  done
+  echo "File modified, killing container: $opt_m" >&2
+  handle_trigger
+}
+
+if [ -n "$opt_e" ]; then
+  check_exists
+elif [ -n "$opt_m" ]; then
+  check_modify
+else
+  echo "Error: No option specified" >&2
+  usage
+fi
+
+


### PR DESCRIPTION
This script is useful for stopping the container on a condition. My current use case is when a shared volume updates with a new certificate and I want my application to use that new certificate. Once the container is killed, orchestration or a restart policy will create a new container leveraging that certificate in the shared volume. Note that you cannot reliably kill pid 1 from inside the container, so usage of this depends on killing a child process stopping the container, which happens if you use an init wrapper like tini.